### PR TITLE
Show times on tram loops/first stops

### DIFF
--- a/common.js
+++ b/common.js
@@ -35,7 +35,6 @@ function checkVersionInit() {
 function parseStatus(status) {
 	switch(status.status) {
 		case 'STOPPING':
-			return lang.boarding_sign;
 		case 'PREDICTED':
 			if(status.actualRelativeTime <= 0)
 				return lang.boarding_sign;

--- a/index.html
+++ b/index.html
@@ -134,8 +134,8 @@
 			</div>
 		</div>
 		<script src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7"  crossorigin="anonymous"></script>
-		<script tyle="text/javascript" src="lang_pl.js" id="lang_script"></script>
-		<script tyle="text/javascript" src="common.js"></script>
+		<script type="text/javascript" src="lang_pl.js" id="lang_script"></script>
+		<script type="text/javascript" src="common.js"></script>
 		<script type="text/javascript" src="index.js"></script>
 	</body>
 </html>

--- a/index.js
+++ b/index.js
@@ -139,7 +139,9 @@ function loadTimes(stopId) {
 			
 			if(data.actual[i].status == 'STOPPING') {
 				tr.className = 'success';
-				status_cell.className = 'status-boarding';
+				if (data.actual[i].actualRelativeTime <= 0) {
+					status_cell.className = 'status-boarding';
+				}
 			} else if(parseInt(delay) > 9) {
 				tr.className = 'danger';
 				delay_cell.className = 'status-delayed';

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function loadTimes(stopId) {
 			var delay = parseDelay(data.actual[i]);
 			var delay_cell = addCellWithText(tr, delay);
 			
-			if(status == lang.boarding_sign) {
+			if(data.actual[i].status == 'STOPPING') {
 				tr.className = 'success';
 				status_cell.className = 'status-boarding';
 			} else if(parseInt(delay) > 9) {


### PR DESCRIPTION
If a tram is waiting for departure at a loop, it would show ">>>" arrows, though it can have a departure in 5 minutes. This pull request fixes that.
On a tram loop there's `STOPPING` status with positive relative time, on normal stops it should always be negative with that same status.
I have tested it and it works. The tram being on a stop can still be distinguished thanks to its green background.